### PR TITLE
Return the placeholder.png in the API if no image is set

### DIFF
--- a/backend/app/api/routes/items/items_resource.py
+++ b/backend/app/api/routes/items/items_resource.py
@@ -68,9 +68,6 @@ async def create_new_item(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=strings.ITEM_ALREADY_EXISTS,
         )
-    image = item_create.image
-    if not image:
-        image = 'placeholder.png'
     item = await items_repo.create_item(
         slug=slug,
         title=item_create.title,
@@ -78,7 +75,7 @@ async def create_new_item(
         body=item_create.body,
         seller=user,
         tags=item_create.tags,
-        image=image
+        image=item_create.image
     )
     send_event('item_created', {'item': item_create.title})
     return ItemInResponse(item=ItemForResponse.from_orm(item))

--- a/backend/app/api/routes/items/items_resource.py
+++ b/backend/app/api/routes/items/items_resource.py
@@ -68,6 +68,9 @@ async def create_new_item(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=strings.ITEM_ALREADY_EXISTS,
         )
+    image = item_create.image
+    if not image:
+        image = 'placeholder.png'
     item = await items_repo.create_item(
         slug=slug,
         title=item_create.title,
@@ -75,7 +78,7 @@ async def create_new_item(
         body=item_create.body,
         seller=user,
         tags=item_create.tags,
-        image=item_create.image
+        image=image
     )
     send_event('item_created', {'item': item_create.title})
     return ItemInResponse(item=ItemForResponse.from_orm(item))

--- a/backend/app/db/repositories/items.py
+++ b/backend/app/db/repositories/items.py
@@ -309,7 +309,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
             title=title,
             description=item_row["description"],
             body=item_row["body"],
-            image=item_row["image"],
+            image=item_row["image"] or 'placeholder.png',
             seller=await self._profiles_repo.get_profile_by_username(
                 username=seller_username,
                 requested_user=requested_user,


### PR DESCRIPTION
# Description

This PR adjusts the API that, in case of no URL being provided for an image the 'placeholder.png' is returned!
